### PR TITLE
fix: restore space between `link` and `rel`

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -128,7 +128,7 @@ export function renderPrefetchLinks (ssrContext: SSRContext, renderContext: Rend
       if (alreadyRendered(file)) {
         return ''
       }
-      return `<link${isModule(file) ? ' type="module" ' : ''}rel="prefetch" href="${renderContext.publicPath}${file}">`
+      return `<link ${isModule(file) ? 'type="module" ' : ''}rel="prefetch" href="${renderContext.publicPath}${file}">`
     }).join('')
   } else {
     return ''


### PR DESCRIPTION
resolves #13