### PR TITLE
fix: add missing `stylesheet` rel for prefetch tags

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -336,7 +336,7 @@ export function renderPreloadLinks (ssrContext: SSRContext, rendererContext: Ren
 export function renderPrefetchLinks (ssrContext: SSRContext, rendererContext: RendererContext): string {
   const { prefetch } = getRequestDependencies(ssrContext, rendererContext)
   return Object.values(prefetch).map(({ path }) =>
-    `<link ${isModule(path) ? 'type="module" ' : ''}rel="prefetch" href="${rendererContext.publicPath}${path}">`
+    `<link ${isModule(path) ? 'type="module" ' : ''}rel="prefetch${isCSS(path) ? ' stylesheet' : '' }" href="${rendererContext.publicPath}${path}">`
   ).join('')
 }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -336,7 +336,7 @@ export function renderPreloadLinks (ssrContext: SSRContext, rendererContext: Ren
 export function renderPrefetchLinks (ssrContext: SSRContext, rendererContext: RendererContext): string {
   const { prefetch } = getRequestDependencies(ssrContext, rendererContext)
   return Object.values(prefetch).map(({ path }) =>
-    `<link ${isModule(path) ? 'type="module" ' : ''}rel="prefetch${isCSS(path) ? ' stylesheet' : '' }" href="${rendererContext.publicPath}${path}">`
+    `<link ${isModule(path) ? 'type="module" ' : ''}rel="prefetch${isCSS(path) ? ' stylesheet' : ''}" href="${rendererContext.publicPath}${path}">`
   ).join('')
 }
 

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -79,7 +79,7 @@ describe('renderer with legacy manifest', () => {
     const result = renderResourceHints().split('>').slice(0, -1).map(s => `${s}>`).sort()
     expect(result).to.deep.equal(
       [
-        '<link rel="prefetch" href="/_nuxt/pages/another.css">', // dynamic import CSS
+        '<link rel="prefetch stylesheet" href="/_nuxt/pages/another.css">', // dynamic import CSS
         '<link rel="prefetch" href="/_nuxt/pages/another.js">', // dynamic import
         '<link rel="preload" href="/_nuxt/app.css" as="style">', // entrypoint CSS
         '<link rel="preload" href="/_nuxt/app.js" as="script">',


### PR DESCRIPTION
- Fixes https://github.com/nuxt-contrib/vue-bundle-renderer/issues/22 & https://github.com/nuxt/framework/issues/2553
- Fixed by using a space separated list of values for `rel`, see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel