### PR TITLE
Update the `shouldPreload()` fallback function to preload all allowed types from `getPreloadType()` output

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -92,7 +92,7 @@ export function createRendererContext ({ clientManifest, publicPath, basedir, sh
   return {
     // User customisation of output
     shouldPrefetch: shouldPrefetch || (() => true),
-    shouldPreload: shouldPreload || ((_file: string, asType: ModuleDependencies['preload'][string]['type']) => ['module', 'script', 'style'].includes(asType as string)),
+    shouldPreload: shouldPreload || ((_file: string, asType: ModuleDependencies['preload'][string]['type']) => typeof asType !== 'undefined'),
     // Manifest
     publicPath: ensureTrailingSlash(publicPath || (clientManifest as any).publicPath || '/'),
     clientManifest: manifest,


### PR DESCRIPTION
Hello.

This is temporary solution for a missing `render` options in the Nuxt 3 framework config, specifically the [`render.bundleRenderer.shouldPreload()`](https://github.com/nuxt/framework/blob/0d85c9ef77360fc1e56450039dc8436bd2390c69/packages/schema/src/config/render.ts#L13
):

```ts
export default defineNuxtConfig({
  render:
    bundleRenderer: {
      shouldPreload: (_fileWithoutQuery, asType) => ['script', 'style', 'font'].includes(asType),
   },
  },
};
```

See also: https://github.com/nuxt/framework/discussions/2291

## An example of usage in the Nuxt 3 framework project

After this pull request is merged, preloading will be based on a file that contains `import` of assets:

###  `app.vue`

Assets will be preloaded using `<link rel="preload" >`, because it's entry point of the Vite `manifest.json`.

```vue
<script lang="ts">
import '@fontsource/open-sans/400.css';
</script>

<script lang="ts" setup>
import { NuxtLayout } from '#components';
</script>

<template>
  <div>
    <NuxtLayout>
      <NuxtPage />
    </NuxtLayout>
  </div>
</template>

<style lang="scss">
@import './assets/styles';
</style>
```

### `layouts/*vue`, `pages/*.vue`, `components/*.vue`

Assets will be prefetched using `<link rel="prefetch" >`.

```vue
<script lang="ts">
import 'katex/dist/katex.css';
</script>

<script setup lang="ts">
import { computed } from 'vue';
import katex from 'katex';

interface Props {
  src: string;
}

const props = defineProps<Props>();
const html = computed(() =>
  katex.renderToString(props.src, {
    strict: false,
  }),
);
</script>

<template>
  <span class="formula" >
    <span v-html="html" />
  </span>
</template>
```

Best wishes,
Sergey.