### PR TITLE
fix: set resource type for css

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -10,7 +10,7 @@ export function normalizeViteManifest (manifest: ViteManifest | Manifest): Manif
     _manifest[file] = { ...parseResource(chunk.file || file), ...chunk }
     for (const item of chunk.css || []) {
       if (!_manifest[item]) {
-        _manifest[item] = { file: item, ...parseResource(item) }
+        _manifest[item] = { file: item, resourceType: 'style', ...parseResource(item) }
       }
     }
     for (const item of chunk.assets || []) {


### PR DESCRIPTION
this adds a fallback to `style` type for css resources, useful in vite dev mode, for example, when `@fs/project/node_modules/@nuxt/ui-templates/dist/templates/error-500.vue?vue&type=style&index=0&scoped=af64d9fa&lang.css` will not be parsed as css