### PR TITLE
fix: do not consider commonjs module script file as esm

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,7 @@ export const parseResource = (path: string) => {
   if (asType) {
     chunk.resourceType = asType
 
-    if (asType === 'script') {
+    if (asType === 'script' && extension !== 'cjs') {
       chunk.module = true
     }
   }


### PR DESCRIPTION
This PR fixes the case where we configure nuxt + webpack to output commonJs modules.
It checks the cjs extension we can configure in nuxt.config.ts within webpack.filenames.app / chunk properties.
If we know for sure that these files are not esm, we might not write a <script type="module> to import them.

This covers the browsers of some SmartTV 2018 Samsung and LG where the browsers are older than Chrome 61 (no support for ESM), but after Chrome 49 for Vue 3 compatibility (Proxy support)
These devices can't have their browser to be updated.
