### PR TITLE
perf: render base resource headers (for early hints)

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -248,6 +248,9 @@ export function createRenderer (createApp: any, renderOptions: RenderOptions & {
 
   return {
     rendererContext,
+    base: {
+      resourceHeaders: renderResourceHeaders({}, rendererContext)
+    },
     async renderToString (ssrContext: SSRContext) {
       ssrContext._registeredComponents = ssrContext._registeredComponents || new Set()
 
@@ -255,7 +258,7 @@ export function createRenderer (createApp: any, renderOptions: RenderOptions & {
       const app = await _createApp(ssrContext)
       const html = await renderOptions.renderToString(app, ssrContext)
 
-      const wrap = <T extends RenderFunction>(fn: T) => () => fn(ssrContext, rendererContext) as ReturnType<T>
+      const wrap = <T extends RenderFunction> (fn: T) => () => fn(ssrContext, rendererContext) as ReturnType<T>
 
       return {
         html,


### PR DESCRIPTION
This renders base resource headers synchronously to the renderer instance, for use _before_ the vue app is rendered.

I've added it via an object `base.resourceHeaders` as we may have use for to prerendering styles/scripts etc. in future.