### PR TITLE
fix!: disable font prefetching by default

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -43,7 +43,7 @@ interface LinkAttributes {
   crossorigin?: '' | null
 }
 
-const defaultShouldPrefetch = () => true
+const defaultShouldPrefetch = (resource: ResourceMeta) => resource.resourceType !== 'font'
 const defaultShouldPreload = (resource: ResourceMeta) => ['module', 'script', 'style'].includes(resource.resourceType || '')
 
 export function createRendererContext ({ manifest, buildAssetsURL, shouldPrefetch, shouldPreload }: RenderOptions): RendererContext {

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -104,8 +104,6 @@ describe('renderer', () => {
         "<link rel=\\"modulepreload\\" as=\\"script\\" crossorigin href=\\"/assets/lazy-component.mjs\\">",
         "<link rel=\\"modulepreload\\" as=\\"script\\" crossorigin href=\\"/assets/vendor.mjs\\">",
         "<link rel=\\"prefetch\\" as=\\"audio\\" href=\\"/assets/lazy-component.mp3\\">",
-        "<link rel=\\"prefetch\\" as=\\"font\\" type=\\"font/woff\\" crossorigin href=\\"/assets/lazy-component.woff\\">",
-        "<link rel=\\"prefetch\\" as=\\"font\\" type=\\"font/woff2\\" crossorigin href=\\"/assets/lazy-component.woff2\\">",
         "<link rel=\\"prefetch\\" as=\\"image\\" type=\\"image/jpeg\\" href=\\"/assets/lazy-component.jpg\\">",
         "<link rel=\\"prefetch\\" as=\\"image\\" type=\\"image/png\\" href=\\"/assets/entry.png\\">",
         "<link rel=\\"prefetch\\" as=\\"image\\" type=\\"image/png\\" href=\\"/assets/lazy-component.png\\">",


### PR DESCRIPTION
we almost never want to prefetch fonts as by default this will include lots of formats (when the browser will only want one, likely) and lots of different font weights/families (even when these may not be used in a page).

it might also be worth considering better defaults for other asset types too.