### PR TITLE
fix: eagerly initialise dependencies cache

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -79,7 +79,7 @@ export function getModuleDependencies (id: string, rendererContext: RendererCont
     return rendererContext._dependencies[id]
   }
 
-  const dependencies: ModuleDependencies = {
+  const dependencies: ModuleDependencies = rendererContext._dependencies[id] = {
     scripts: {},
     styles: {},
     preload: {},
@@ -89,7 +89,6 @@ export function getModuleDependencies (id: string, rendererContext: RendererCont
   const meta = rendererContext.manifest[id]
 
   if (!meta) {
-    rendererContext._dependencies[id] = dependencies
     return dependencies
   }
 
@@ -122,7 +121,6 @@ export function getModuleDependencies (id: string, rendererContext: RendererCont
   }
   dependencies.preload = filteredPreload
 
-  rendererContext._dependencies[id] = dependencies
   return dependencies
 }
 
@@ -255,7 +253,7 @@ export function createRenderer (createApp: any, renderOptions: RenderOptions & {
       const app = await _createApp(ssrContext)
       const html = await renderOptions.renderToString(app, ssrContext)
 
-      const wrap = <T extends RenderFunction>(fn: T) => () => fn(ssrContext, rendererContext) as ReturnType<T>
+      const wrap = <T extends RenderFunction> (fn: T) => () => fn(ssrContext, rendererContext) as ReturnType<T>
 
       return {
         html,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19837

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

To avoid circular dependency errors, we can eagerly initialise the dependency cache. This means that any parent ids/dependencies we need to resolve can be resolved.

**Note**: This was only replicable with the nitro prerender build target, so I don't expect this to affect production vue rendering.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
