### PR TITLE
feat!: add `preload` and `prefetch` attributes to manifest

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -22,13 +22,11 @@ export interface SSRContext {
 }
 
 export interface RenderOptions {
-  shouldPrefetch?: (resource: ResourceMeta) => boolean
-  shouldPreload?: (resource: ResourceMeta) => boolean
   buildAssetsURL?: (id: string) => string
   manifest: Manifest
 }
 
-export interface RendererContext extends Pick<RenderOptions, 'shouldPrefetch' | 'shouldPreload'>, Required<Pick<RenderOptions, 'buildAssetsURL' | 'manifest'>> {
+export interface RendererContext extends Required<RenderOptions> {
   _dependencies: Record<string, ModuleDependencies>
   _dependencySets: Record<string, ModuleDependencies>
   _entrypoints: string[]
@@ -43,11 +41,8 @@ interface LinkAttributes {
   crossorigin?: '' | null
 }
 
-export function createRendererContext ({ manifest, buildAssetsURL, shouldPrefetch, shouldPreload }: RenderOptions): RendererContext {
+export function createRendererContext ({ manifest, buildAssetsURL }: RenderOptions): RendererContext {
   const ctx: RendererContext = {
-    // User customisation of output
-    shouldPrefetch,
-    shouldPreload,
     // Manifest
     buildAssetsURL: buildAssetsURL || withLeadingSlash,
     manifest: undefined!,
@@ -115,7 +110,7 @@ export function getModuleDependencies (id: string, rendererContext: RendererCont
   const filteredPreload: ModuleDependencies['preload'] = {}
   for (const id in dependencies.preload) {
     const dep = dependencies.preload[id]
-    if (rendererContext.shouldPreload ? rendererContext.shouldPreload(dep) : dep.preload) {
+    if (dep.preload) {
       filteredPreload[id] = dep
     }
   }
@@ -155,7 +150,7 @@ export function getAllDependencies (ids: Set<string>, rendererContext: RendererC
   const filteredPrefetch: ModuleDependencies['prefetch'] = {}
   for (const id in allDeps.prefetch) {
     const dep = allDeps.prefetch[id]
-    if (rendererContext.shouldPrefetch ? rendererContext.shouldPrefetch(dep) : dep.prefetch) {
+    if (dep.prefetch) {
       filteredPrefetch[id] = dep
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,10 @@ export interface ResourceMeta {
   sideEffects?: boolean
   imports?: string[]
   dynamicImports?: string[]
-  // Augmentation for vue-bundle-renderer
+  // Augmentations for vue-bundle-renderer
   module?: boolean
+  prefetch?: boolean
+  preload?: boolean
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#what_types_of_content_can_be_preloaded
   resourceType?: 'audio' | 'document' | 'embed' | 'fetch' | 'font' | 'image' | 'object' | 'script' | 'style' | 'track' | 'worker' | 'video'
   mimeType?: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,14 @@ export const parseResource = (path: string) => {
     }
   }
 
+  if (chunk.resourceType !== 'font') {
+    chunk.prefetch = true
+  }
+
+  if (chunk.resourceType && ['module', 'script', 'style'].includes(chunk.resourceType)) {
+    chunk.preload = true
+  }
+
   const contentType = getContentType(asType, extension)
   if (contentType) {
     chunk.mimeType = contentType

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -6,104 +6,129 @@ import webpackManifest from './fixtures/webpack-manifest.json'
 
 describe('webpack manifest', () => {
   it('should normalize manifest', () => {
-    expect(normalizeWebpackManifest(webpackManifest)).to.deep.equal({
-      '4d87aad8': {
-        file: '',
-        assets: [],
-        css: [
-          'app.css'
-        ],
-        imports: [
-          '_app.js'
-        ]
-      },
-      '56940b2e': {
-        file: '',
-        assets: [
-          'img/logo.41f2f89.svg'
-        ],
-        css: [
-          'some.css'
-        ],
-        imports: [
-          '_pages/index.js'
-        ]
-      },
-      '630f1d84': {
-        file: '',
-        assets: [],
-        css: [
-          'app.css'
-        ],
-        imports: [
-          '_app.js'
-        ]
-      },
-      _LICENSES: {
-        file: 'LICENSES'
-      },
-      '_pages/another.css': {
-        css: [
-          'pages/another.css'
-        ],
-        file: ''
-      },
-      '_app.js': {
-        resourceType: 'script',
-        file: 'app.js',
-        isEntry: true,
-        module: true
-      },
-      '_commons/app.js': {
-        resourceType: 'script',
-        file: 'commons/app.js',
-        isEntry: true,
-        module: true
-      },
-      '_pages/another.js': {
-        resourceType: 'script',
-        file: 'pages/another.js',
-        isDynamicEntry: true,
-        sideEffects: true,
-        module: true
-      },
-      '_pages/index.js': {
-        resourceType: 'script',
-        file: 'pages/index.js',
-        isDynamicEntry: true,
-        sideEffects: true,
-        module: true
-      },
-      '_runtime.js': {
-        resourceType: 'script',
-        assets: [],
-        css: ['app.css'],
-        dynamicImports: [
-          '_pages/another.css',
-          '_pages/another.js',
-          '_pages/index.js'
-        ],
-        file: 'runtime.js',
-        isEntry: true,
-        module: true
-      },
-      'app.css': {
-        resourceType: 'style',
-        file: 'app.css'
-      },
-      'img/logo.41f2f89.svg': {
-        file: 'img/logo.41f2f89.svg',
-        mimeType: 'image/svg+xml',
-        resourceType: 'image'
-      },
-      'pages/another.css': {
-        resourceType: 'style',
-        file: 'pages/another.css'
-      },
-      'some.css': {
-        file: 'some.css',
-        resourceType: 'style'
+    expect(normalizeWebpackManifest(webpackManifest)).toMatchInlineSnapshot(`
+      {
+        "4d87aad8": {
+          "assets": [],
+          "css": [
+            "app.css",
+          ],
+          "file": "",
+          "imports": [
+            "_app.js",
+          ],
+          "prefetch": true,
+        },
+        "56940b2e": {
+          "assets": [
+            "img/logo.41f2f89.svg",
+          ],
+          "css": [
+            "some.css",
+          ],
+          "file": "",
+          "imports": [
+            "_pages/index.js",
+          ],
+          "prefetch": true,
+        },
+        "630f1d84": {
+          "assets": [],
+          "css": [
+            "app.css",
+          ],
+          "file": "",
+          "imports": [
+            "_app.js",
+          ],
+          "prefetch": true,
+        },
+        "_LICENSES": {
+          "file": "LICENSES",
+          "prefetch": true,
+        },
+        "_app.js": {
+          "file": "app.js",
+          "isEntry": true,
+          "module": true,
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "script",
+        },
+        "_commons/app.js": {
+          "file": "commons/app.js",
+          "isEntry": true,
+          "module": true,
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "script",
+        },
+        "_pages/another.css": {
+          "css": [
+            "pages/another.css",
+          ],
+          "file": "",
+        },
+        "_pages/another.js": {
+          "file": "pages/another.js",
+          "isDynamicEntry": true,
+          "module": true,
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "script",
+          "sideEffects": true,
+        },
+        "_pages/index.js": {
+          "file": "pages/index.js",
+          "isDynamicEntry": true,
+          "module": true,
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "script",
+          "sideEffects": true,
+        },
+        "_runtime.js": {
+          "assets": [],
+          "css": [
+            "app.css",
+          ],
+          "dynamicImports": [
+            "_pages/another.css",
+            "_pages/another.js",
+            "_pages/index.js",
+          ],
+          "file": "runtime.js",
+          "isEntry": true,
+          "module": true,
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "script",
+        },
+        "app.css": {
+          "file": "app.css",
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "style",
+        },
+        "img/logo.41f2f89.svg": {
+          "file": "img/logo.41f2f89.svg",
+          "mimeType": "image/svg+xml",
+          "prefetch": true,
+          "resourceType": "image",
+        },
+        "pages/another.css": {
+          "file": "pages/another.css",
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "style",
+        },
+        "some.css": {
+          "file": "some.css",
+          "prefetch": true,
+          "preload": true,
+          "resourceType": "style",
+        },
       }
-    })
+    `)
   })
 })

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -7,6 +7,6 @@ import type { Manifest, ResourceMeta } from '../src/types'
 describe('manifest', () => {
   it('matches vite types', () => {
     expectTypeOf<ViteManifest>().toMatchTypeOf<Manifest>()
-    expectTypeOf<ViteManifest>().toEqualTypeOf<Record<string, Omit<ResourceMeta, 'resourceType' | 'module' | 'mimeType' | 'sideEffects'>>>()
+    expectTypeOf<ViteManifest>().toEqualTypeOf<Record<string, Omit<ResourceMeta, 'resourceType' | 'module' | 'mimeType' | 'sideEffects' | 'preload' | 'prefetch'>>>()
   })
 })


### PR DESCRIPTION
resolves #45

This adds backwards-compatible build-time analysis on whether to prefetch/preload resources. ~~It should be exactly compatible with current default runtime values as moves the runtime code to build-time (and defers to any custom shouldPrefetch/shouldPreload that is passed).~~

Refactored to be a breaking change.