### PR TITLE
ci: run test suite on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable


### PR DESCRIPTION

This PR aims to run tests on Windows in CI, to avoid potential regressions.

related: https://github.com/nuxt/ecosystem-ci/pull/15