### PR TITLE
fix: fold dynamicImports prefetch into `precomputeDependencies`

### DIFF
--- a/src/precompute.ts
+++ b/src/precompute.ts
@@ -92,6 +92,15 @@ export function precomputeDependencies(manifest: Manifest): PrecomputedData {
     }
     deps.preload = filteredPreload
 
+    // Dynamically imported modules and their static deps are prefetch hints
+    // for the parent.
+    for (const dynamicDepId of meta.dynamicImports || []) {
+      const dynamicDeps = computeDependencies(dynamicDepId)
+      Object.assign(deps.prefetch, dynamicDeps.scripts)
+      Object.assign(deps.prefetch, dynamicDeps.styles)
+      Object.assign(deps.prefetch, dynamicDeps.preload)
+    }
+
     dependencies[id] = deps
     computing.delete(id)
     return deps

--- a/test/precompute.test.ts
+++ b/test/precompute.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createRenderer } from '../src/runtime'
 import { precomputeDependencies } from '../src/precompute'
 import { normalizeViteManifest } from '../src/vite'
+import type { Manifest } from '../src/types'
 import viteManifest from './fixtures/vite-manifest.json'
 
 describe('precomputed dependencies', () => {
@@ -62,6 +63,72 @@ describe('precomputed dependencies', () => {
     const precomputedResult = await precomputedRenderer.renderToString({ modules })
 
     // Should produce identical output
+    expect(precomputedResult.renderStyles()).toBe(manifestResult.renderStyles())
+    expect(precomputedResult.renderScripts()).toBe(manifestResult.renderScripts())
+    expect(precomputedResult.renderResourceHints()).toBe(manifestResult.renderResourceHints())
+  })
+
+  it('should produce same results as manifest-based approach when dynamicImports are present', async () => {
+    const manifest: Manifest = {
+      'pages/index.vue': {
+        file: 'index.mjs',
+        isEntry: true,
+        resourceType: 'script',
+        module: true,
+        preload: true,
+        imports: ['vendor.mjs'],
+        dynamicImports: ['components/lazy.vue'],
+        css: ['index.css'],
+      },
+      'vendor.mjs': {
+        file: 'vendor.mjs',
+        resourceType: 'script',
+        module: true,
+        preload: true,
+      },
+      'index.css': {
+        file: 'index.css',
+        resourceType: 'style',
+        preload: true,
+        prefetch: true,
+      },
+      'components/lazy.vue': {
+        file: 'lazy.mjs',
+        resourceType: 'script',
+        module: true,
+        preload: true,
+        prefetch: true,
+        imports: ['vendor.mjs'],
+        css: ['lazy.css'],
+      },
+      'lazy.css': {
+        file: 'lazy.css',
+        resourceType: 'style',
+        preload: true,
+        prefetch: true,
+      },
+    }
+
+    const precomputed = precomputeDependencies(manifest)
+
+    const manifestRenderer = createRenderer(() => ({}), {
+      manifest,
+      renderToString: () => '<div>test</div>',
+      buildAssetsURL: id => `/_nuxt/${id}`,
+    })
+
+    const precomputedRenderer = createRenderer(() => ({}), {
+      precomputed,
+      renderToString: () => '<div>test</div>',
+      buildAssetsURL: id => `/_nuxt/${id}`,
+    })
+
+    const modules = new Set(['pages/index.vue'])
+
+    const manifestResult = await manifestRenderer.renderToString({ modules })
+    const precomputedResult = await precomputedRenderer.renderToString({ modules })
+
+    expect(manifestResult.renderResourceHints()).toContain('lazy.mjs')
     expect(precomputedResult.renderStyles()).toBe(manifestResult.renderStyles())
     expect(precomputedResult.renderScripts()).toBe(manifestResult.renderScripts())
     expect(precomputedResult.renderResourceHints()).toBe(manifestResult.renderResourceHints())


### PR DESCRIPTION
fixes a bug where precomputed-only mode silently produced empty results, so manifest-mode and precomputed-mode renderers emitted different `renderResourceHints()` output whenever a used module had dynamicImports