### PR TITLE
chore: exempt first-party packages from pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 allowBuilds:
   esbuild: false
   unrs-resolver: false
+
+minimumReleaseAgeExclude:
+  - nuxt
+  - nuxt-nightly
+  - '@nuxt/*'
+  - vue
+  - '@vue/*'


### PR DESCRIPTION
because this repo extends [nuxt's renovate preset](https://github.com/nuxt/renovate-config-nuxt/blob/main/default.json#L22-L28), which itself excludes these first-party packages from the release age check, it's necessary to update `pnpm-workspace.yaml` to mirror the same list to avoid artifact update failures.