### PR TITLE
fix: don't hoist nested dynamic imports into entry prefetch set

### DIFF
--- a/src/precompute.ts
+++ b/src/precompute.ts
@@ -7,7 +7,7 @@ export interface PrecomputedData {
   /** List of entry point module IDs */
   entrypoints: string[]
   /** Module metadata needed at runtime (file paths, etc.) */
-  modules: Record<string, Pick<ResourceMeta, 'file' | 'resourceType' | 'mimeType' | 'module'>>
+  modules: Record<string, Pick<ResourceMeta, 'file' | 'resourceType' | 'mimeType' | 'module' | 'dynamicImports'>>
 }
 
 /**
@@ -92,15 +92,6 @@ export function precomputeDependencies(manifest: Manifest): PrecomputedData {
     }
     deps.preload = filteredPreload
 
-    // Dynamically imported modules and their static deps are prefetch hints
-    // for the parent.
-    for (const dynamicDepId of meta.dynamicImports || []) {
-      const dynamicDeps = computeDependencies(dynamicDepId)
-      Object.assign(deps.prefetch, dynamicDeps.scripts)
-      Object.assign(deps.prefetch, dynamicDeps.styles)
-      Object.assign(deps.prefetch, dynamicDeps.preload)
-    }
-
     dependencies[id] = deps
     computing.delete(id)
     return deps
@@ -121,13 +112,16 @@ export function precomputeDependencies(manifest: Manifest): PrecomputedData {
   }
 
   // Extract minimal module metadata needed at runtime
-  const modules: Record<string, Pick<ResourceMeta, 'file' | 'resourceType' | 'mimeType' | 'module'>> = {}
+  const modules: PrecomputedData['modules'] = {}
   for (const [moduleId, meta] of Object.entries(manifest)) {
     modules[moduleId] = {
       file: meta.file,
       resourceType: meta.resourceType,
       mimeType: meta.mimeType,
       module: meta.module,
+    }
+    if (meta.dynamicImports?.length) {
+      modules[moduleId].dynamicImports = meta.dynamicImports
     }
   }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -220,7 +220,8 @@ export function getAllDependencies(ids: Set<string>, rendererContext: RendererCo
       allDeps.prefetch[key] = deps.prefetch[key]
     }
 
-    for (const dynamicDepId of rendererContext.manifest?.[id]?.dynamicImports || []) {
+    const dynamicImports = rendererContext.manifest?.[id]?.dynamicImports || rendererContext.precomputed?.modules[id]?.dynamicImports || []
+    for (const dynamicDepId of dynamicImports) {
       const dynamicDeps = getModuleDependencies(dynamicDepId, rendererContext)
       for (const key in dynamicDeps.scripts) {
         allDeps.prefetch[key] = dynamicDeps.scripts[key]

--- a/test/precompute.test.ts
+++ b/test/precompute.test.ts
@@ -134,6 +134,42 @@ describe('precomputed dependencies', () => {
     expect(precomputedResult.renderResourceHints()).toBe(manifestResult.renderResourceHints())
   })
 
+  it('should not hoist nested dynamic imports into the entry prefetch set', async () => {
+    const chunk = (file: string, extra: Partial<Manifest[string]> = {}): Manifest[string] => ({
+      file,
+      resourceType: 'script',
+      module: true,
+      prefetch: true,
+      preload: true,
+      ...extra,
+    })
+
+    const manifest: Manifest = {
+      entry: chunk('entry.js', { isEntry: true, imports: ['app'] }),
+      app: chunk('app.js', { imports: ['loader'] }),
+      loader: chunk('loader.js', { dynamicImports: ['step'] }),
+      step: chunk('step.js'),
+    }
+
+    const manifestRenderer = createRenderer(() => ({}), {
+      manifest,
+      renderToString: () => '<div>test</div>',
+      buildAssetsURL: id => `/_nuxt/${id}`,
+    })
+
+    const precomputedRenderer = createRenderer(() => ({}), {
+      precomputed: precomputeDependencies(manifest),
+      renderToString: () => '<div>test</div>',
+      buildAssetsURL: id => `/_nuxt/${id}`,
+    })
+
+    const manifestResult = await manifestRenderer.renderToString({})
+    const precomputedResult = await precomputedRenderer.renderToString({})
+
+    expect(manifestResult.renderResourceHints()).not.toContain('step.js')
+    expect(precomputedResult.renderResourceHints()).toBe(manifestResult.renderResourceHints())
+  })
+
   it('should throw error when neither manifest nor precomputed provided', () => {
     expect(() => {
       createRenderer(() => ({}), {


### PR DESCRIPTION
resolve #353

this reconciles a disagreement introduced in #351 between manifest vs precomputed mode. for a graph like `entry --static--> app --static--> loader --dynamic--> step`, manifest mode prefetches nothing but precomputed mode prefetches `step`:

```ts
const manifest = () => ({
  entry: chunk('entry.js', { isEntry: true, imports: ['app'] }),
  app: chunk('app.js', { imports: ['loader'] }),
  loader: chunk('loader.js', { dynamicImports: ['step'] }),
  step: chunk('step.js'),
})

getRequestDependencies({}, createRendererContext({ manifest: manifest() })).prefetch // {}
getRequestDependencies({}, createRendererContext({ precomputed: precomputeDependencies(manifest()) })).prefetch // { step }
```
